### PR TITLE
Added a filter so users can not enable auto updates via action if plugin has disabled auto-updates.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,10 @@ To test/contribute, just install this plugin and activate it on your WordPress i
 
 The goal of this plugin is to test the UI of the feature, to help decision making. It uses WordPress Core hooks (with potentially some hacks when needed).
 
+For full details, see the [Feature Plugin proposal published on Make/Core](https://make.wordpress.org/core/2020/02/26/feature-plugin-wp-auto-updates/).
+
+Interested in contributing to this plugin? Feel free to join us in `#core-auto-updates` channel on Make WordPress Slack Team. We’ll host weekly meetings on Slack every Tuesdays at 18:00 UTC.
+
 ## Context ⏳
 
 In 2018, Matt Mullenweg posted 9 projects for Core to focus on in 2019. We didn’t ship as many as hoped, but we made a lot of progress. Plugins and Themes Automatic Updates were one of those 9 projects. This project is now milestoned to WordPress 5.5 and this feature plugin is here to help move towards this achievement.
@@ -24,6 +28,13 @@ In 2018, Matt Mullenweg posted 9 projects for Core to focus on in 2019. We didn�
 
 - ✅ Open a Trac ticket to handle Core merge for plugins
 - ✅ Open a Trac ticket to handle Core merge for themes
+- ✅ Create and add feature plugin assets
+- ✅ Submit Feature Plugin on WordPress.org repository
+- ✅ Get the plugin featured as beta plugin on WordPress.org
+- 🔲 Move the repository to WordPress.org GitHub account
+- ✅ Publish the feature plugin proposal
+- ✅ Open a dedicated Slack channel on Make WordPress
+- ✅ Launch weekly meetings on Slack
 - ✅ Handle plugin auto-updates
 - 🔲 Handle themes auto-updates
 - ✅ Handle plugin auto-updates in a multisite context
@@ -34,19 +45,15 @@ In 2018, Matt Mullenweg posted 9 projects for Core to focus on in 2019. We didn�
 - 🔲 Validate design for themes screen
 - 🔲 Validate design for update-core screen
 - 🔲 Documentation
-- ✅ Create and add feature plugin assets
-- ✅ Submit Feature Plugin on WordPress.org repository
-- ✅ Get the plugin featured as beta plugin on WordPress.org
-- 🔲 Move the repository to WordPress.org GitHub account
-- 🔲 Publish the feature plugin proposal
-- 🔲 Open a dedicated Slack channel on Make WordPress
 - 🔲 Copy review
 - 🔲 Accessibility audit
 - 🔲 Security audit
 - 🔲 Coding standards audit
 - 🔲 Inline Docs audit
 
-## Contributors 👥
+## Contributors ♥️
+
+Thanks to everyone who contributed to this feature plugin!
 
 - [@audrasjb](https://profiles.wordpress.org/audrasjb/)
 - [@whodunitagency](https://profiles.wordpress.org/whodunitagency/)
@@ -55,10 +62,19 @@ In 2018, Matt Mullenweg posted 9 projects for Core to focus on in 2019. We didn�
 - [@pedromendonca](https://profiles.wordpress.org/pedromendonca/)
 - [@javiercasares](https://profiles.wordpress.org/javiercasares/)
 - [@karmatosed](https://profiles.wordpress.org/karmatosed/)
+- [@mapk](https://profiles.wordpress.org/mapk/)
+- [@afercia](https://profiles.wordpress.org/afercia/)
+- [@gmays](https://profiles.wordpress.org/gmays/)
+- [@knutsp](https://profiles.wordpress.org/knutsp/)
+- [@pbiron](https://profiles.wordpress.org/pbiron/)
+- [@passionate](https://profiles.wordpress.org/passionate/)
+- [@nicolaskulka](https://profiles.wordpress.org/nicolaskulka/)
+- [@bookdude13](https://profiles.wordpress.org/bookdude13/)
+- [@sebd86](https://profiles.wordpress.org/sebd86/)
 
 ## Documentation 📚
 
-TODO.
+Work in progress.
 
 ## Screenshots 🖼
 
@@ -70,9 +86,9 @@ TODO.
 
 ![Plugins Admin screen - Toggle update single plugin - animated screenshot](https://jeanbaptisteaudras.com/images/wp-autoupdates-togglesingleplugin-01.gif)
 
-### Plugins Admin screen - Buk Edit - animated screenshot
+### Plugins Admin screen - Bulk Edit - animated screenshot
 
-![Plugins Admin screen - Buk Edit - animated screenshot](https://jeanbaptisteaudras.com/images/wp-autoupdates-bulkeditplugins-01.gif)
+![Plugins Admin screen - Bulk Edit - animated screenshot](https://jeanbaptisteaudras.com/images/wp-autoupdates-bulkeditplugins-01.gif)
 
 ### Update Core Admin Screen
 
@@ -80,11 +96,30 @@ TODO.
 
 ## Changelog 🗓
 
-### Version 0.1.4
+### 0.2 🐝
+March 6, 2020
+- Remove auto-updates column from mustuse and dropins screens - [#39](https://github.com/audrasjb/wp-autoupdates/pull/39)
+- Ensure the the enable/disable bulk actions appear in the dropdown and are handled in multisite - [#38](https://github.com/audrasjb/wp-autoupdates/pull/38)
+- Remove dashicon from "Enable" text in plugins auto-updates column - [#36](https://github.com/audrasjb/wp-autoupdates/pull/36)
+- Replace "Automatic Updates" with "Auto-updates" in filters - [#35](https://github.com/audrasjb/wp-autoupdates/pull/35)
+- Display only filters with at least one available plugin - [#33](https://github.com/audrasjb/wp-autoupdates/pull/33)
+- Remove setting from site option when deleting plugin - [#32](https://github.com/audrasjb/wp-autoupdates/pull/32)
+- Populate site health with plugins auto-updates informations - [#24](https://github.com/audrasjb/wp-autoupdates/pull/24)
+- In multisite, only add the "Automatic Updates" column on the plugins-network screen - [#21](https://github.com/audrasjb/wp-autoupdates/pull/21)
+- Add auto-update-enabled and auto-update-disabled views on the plugins screen - [#18](https://github.com/audrasjb/wp-autoupdates/pull/18)
+
+### Version 0.1.5 🐣
+February 26, 2020
+- Fix fatal error on PHP 7+
+- Fix legacy notice classes
+- Various tiny enhancements
+- Replace required PHP version
+
+### Version 0.1.4 👻
 February 26, 2020
 - Fix PHP warnings.
 
-### Version 0.1.3
+### Version 0.1.3 ☀️
 February 25, 2020
 - Replace all "autoupdate" occurrences with "auto-update" which is now the official wording.
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,9 @@
 === WordPress Auto-updates ===
-Contributors: wordpressdotorg, audrasjb, whodunitagency, desrosj, xkon, karmatosed
+Contributors: wordpressdotorg, audrasjb, whodunitagency, pbiron, xkon, karmatosed, mapk
 Requires at least: 5.3
 Tested up to: 5.4
-Requires PHP: 7.2
-Tested up to: 5.4
-Stable tag: 0.1.4
+Requires PHP: 5.6
+Stable tag: 0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -20,47 +19,42 @@ The purpose of this plugin is to prepare a future Plugins & Themes automatic upd
 
 In 2018, Matt Mullenweg posted 9 projects for Core to focus on in 2019. We didn’t ship as many as hoped, but we made a lot of progress. Plugins and Themes Automatic Updates were one of those 9 projects. This project is now milestoned to WordPress 5.5 and this feature plugin is here to help move towards this achievement.
 
+For full details, see the [Feature Plugin proposal published on Make/Core](https://make.wordpress.org/core/2020/02/26/feature-plugin-wp-auto-updates/).
+
 - [See also: Update on the 9 projects for 2019](https://make.wordpress.org/core/2019/12/06/update-9-projects-for-2019/):
 - [Related Trac ticket for plugins auto-updates](https://core.trac.wordpress.org/ticket/48850)
 - [Related Trac ticket for themes auto-updates](https://core.trac.wordpress.org/ticket/48850)
 
 [This project is currently developed on GitHub](https://github.com/audrasjb/wp-autoupdates)
 
-To test/contribute, just install this plugin and activate it on your WordPress installation.
-
-**Features / to-do list** 🛠
-
-- ✅ Open a Trac ticket to handle Core merge for plugins
-- ✅ Open a Trac ticket to handle Core merge for themes
-- ✅ Handle plugin auto-updates
-- 🔲 Handle themes auto-updates
-- ✅ Handle plugin auto-updates in a multisite context
-- 🔲 Handle themes auto-updates in a multisite context
-- 🔲 Email notifications for plugins
-- 🔲 Email notifications for themes
-- 🔲 Validate design for plugins screen
-- 🔲 Validate design for themes screen
-- 🔲 Validate design for update-core screen
-- 🔲 Documentation
-- ✅ Create and add feature plugin assets
-- ✅ Submit Feature Plugin on WordPress.org repository
-- ✅ Get the plugin featured as beta plugin on WordPress.org
-- 🔲 Move the repository to WordPress.org GitHub account
-- 🔲 Publish the feature plugin proposal
-- 🔲 Open a dedicated Slack channel on Make WordPress
-- 🔲 Copy review
-- 🔲 Accessibility audit
-- 🔲 Security audit
-- 🔲 Coding standards audit
-- 🔲 Inline Docs audit
+Interested in contributing to this plugin? Feel free to join us in `#core-auto-updates` channel on Make WordPress Slack Team. We’ll host weekly meetings on Slack every Tuesdays at 18:00 UTC.
 
 == Changelog ==
 
-= Version 0.1.4 =
+= 0.2 =
+March 6, 2020
+- Remove auto-updates column from mustuse and dropins screens - [#39](https://github.com/audrasjb/wp-autoupdates/pull/39)
+- Ensure the the enable/disable bulk actions appear in the dropdown and are handled in multisite - [#38](https://github.com/audrasjb/wp-autoupdates/pull/38)
+- Remove dashicon from "Enable" text in plugins auto-updates column - [#36](https://github.com/audrasjb/wp-autoupdates/pull/36)
+- Replace "Automatic Updates" with "Auto-updates" in filters - [#35](https://github.com/audrasjb/wp-autoupdates/pull/35)
+- Display only filters with at least one available plugin - [#33](https://github.com/audrasjb/wp-autoupdates/pull/33)
+- Remove setting from site option when deleting plugin - [#32](https://github.com/audrasjb/wp-autoupdates/pull/32)
+- Populate site health with plugins auto-updates informations - [#24](https://github.com/audrasjb/wp-autoupdates/pull/24)
+- In multisite, only add the "Automatic Updates" column on the plugins-network screen - [#21](https://github.com/audrasjb/wp-autoupdates/pull/21)
+- Add auto-update-enabled and auto-update-disabled views on the plugins screen - [#18](https://github.com/audrasjb/wp-autoupdates/pull/18)
+
+= 0.1.5 =
+February 26, 2020
+- Fix fatal error on PHP 7+
+- Fix legacy notice classes
+- Various tiny enhancements
+- Replace required PHP version
+
+= 0.1.4 =
 February 26, 2020
 - Fix PHP warnings.
 
-= Version 0.1.3 =
+= 0.1.3 =
 February 25, 2020
 - Replace all "autoupdate" occurrences with "auto-update" which is now the official wording.
 

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -293,12 +293,12 @@ add_action( 'handle_bulk_actions-plugins', 'wp_autoupdates_plugins_bulk_actions_
 function wp_autoupdates_notices() {
 	// Plugins screen
 	if ( isset( $_GET['enable-autoupdate'] ) ) {
-		echo '<div id="message" class="updated notice is-dismissible"><p>';
+		echo '<div id="message" class="notice notice-success is-dismissible"><p>';
 		_e( 'The selected plugins will now update automatically.', 'wp-autoupdates' );
 		echo '</p></div>';
 	}
 	if ( isset( $_GET['disable-autoupdate'] ) ) {
-		echo '<div id="message" class="updated notice is-dismissible"><p>';
+		echo '<div id="message" class="notice notice-success is-dismissible"><p>';
 		_e( 'The selected plugins won’t automatically update anymore.', 'wp-autoupdates' );
 		echo '</p></div>';
 	}

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -9,7 +9,7 @@ Requires PHP: 7.2
 Tested up to: 5.3
 Author: The WordPress Team
 Author URI: https://wordpress.org
-Contributors: wordpressdotorg, audrasjb, whodunitagency, desrosj, xkon, karmatosed
+Contributors: wordpressdotorg, audrasjb, whodunitagency, desrosj, xkon, karmatosed, sebd86
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: wp-autoupdates
@@ -109,7 +109,7 @@ function wp_autoupdates_add_plugins_autoupdates_column_content( $column_name, $p
 	$plugins = get_plugins();
 	$plugins_updates = get_site_transient( 'update_plugins' );
 	$page = isset( $_GET['paged'] ) && ! empty( $_GET['paged'] ) ? wp_unslash( esc_html( $_GET['paged'] ) ) : '';
-	if ( wp_autoupdates_is_plugins_auto_update_enabled() ) {
+	if ( wp_autoupdates_is_plugins_auto_update_enabled() && wp_autoupdates_plugin_allows_auto_update( $plugin_file ) ) {
 		$wp_auto_update_plugins = get_site_option( 'wp_auto_update_plugins', array() );
 		if ( in_array( $plugin_file, $wp_auto_update_plugins, true ) ) {
 			$aria_label = esc_attr(
@@ -293,15 +293,24 @@ add_action( 'handle_bulk_actions-plugins', 'wp_autoupdates_plugins_bulk_actions_
 function wp_autoupdates_notices() {
 	// Plugins screen
 	if ( isset( $_GET['enable-autoupdate'] ) ) {
-		echo '<div id="message" class="notice notice-success is-dismissible"><p>';
+		echo '<div id="message" class="updated notice is-dismissible"><p>';
 		_e( 'The selected plugins will now update automatically.', 'wp-autoupdates' );
 		echo '</p></div>';
 	}
 	if ( isset( $_GET['disable-autoupdate'] ) ) {
-		echo '<div id="message" class="notice notice-success is-dismissible"><p>';
+		echo '<div id="message" class="updated notice is-dismissible"><p>';
 		_e( 'The selected plugins won’t automatically update anymore.', 'wp-autoupdates' );
 		echo '</p></div>';
 	}
 }
 add_action( 'admin_notices', 'wp_autoupdates_notices' );
 
+/**
+ * Allows a plugin to decide if auto updates is an option for user to enable.
+ *
+ * @param  string $plugin_file
+ * @return bool   Returns true or false if auto-updates are allowed.
+ */
+function wp_autoupdates_plugin_allows_auto_update( $plugin_file ) {
+	return apply_filters( 'wp_plugin_allows_auto_update', true, $plugin_file );
+}

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -3,13 +3,13 @@
 Plugin Name: WordPress Autoupdates
 Plugin URI: https://wordpress.org/plugins/wp-autoupdates
 Description: A feature plugin to integrate Plugins & Themes automatic updates in WordPress Core.
-Version: 0.1.4
+Version: 0.2
 Requires at least: 5.3
-Requires PHP: 7.2
-Tested up to: 5.3
+Requires PHP: 5.6
+Tested up to: 5.4
 Author: The WordPress Team
 Author URI: https://wordpress.org
-Contributors: wordpressdotorg, audrasjb, whodunitagency, desrosj, xkon, karmatosed, sebd86
+Contributors: wordpressdotorg, audrasjb, whodunitagency, pbiron, xkon, karmatosed, mapk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: wp-autoupdates
@@ -28,7 +28,7 @@ function wp_autoupdates_enqueues( $hook ) {
 	}
 	wp_register_style( 'wp-autoupdates', plugin_dir_url( __FILE__ ) . 'css/wp-autoupdates.css', array() );
 	wp_enqueue_style( 'wp-autoupdates' );
-	
+
 	// Update core screen JS hack (due to lack of filters)
 	if ( 'update-core.php' === $hook ) {
 		$script = 'jQuery( document ).ready(function() {';
@@ -87,11 +87,12 @@ add_filter( 'auto_update_plugin', 'wp_autoupdates_selected_plugins', 10, 2 );
  * Add autoupdate column to plugins screen.
  */
 function wp_autoupdates_add_plugins_autoupdates_column( $columns ) {
-	$columns['autoupdates_column'] = __( 'Automatic updates', 'wp-autoupdates' );
+	if ( ! isset( $_GET['plugin_status'] ) || ( 'mustuse' !== $_GET['plugin_status'] && 'dropins' !== $_GET['plugin_status'] ) ) {
+		$columns['autoupdates_column'] = __( 'Automatic updates', 'wp-autoupdates' );
+	}
 	return $columns;
 }
-add_filter( 'manage_plugins_columns', 'wp_autoupdates_add_plugins_autoupdates_column' );
-
+add_filter( is_multisite() ? 'manage_plugins-network_columns' : 'manage_plugins_columns', 'wp_autoupdates_add_plugins_autoupdates_column' );
 
 /**
  * Render autoupdate column’s content.
@@ -100,17 +101,23 @@ function wp_autoupdates_add_plugins_autoupdates_column_content( $column_name, $p
 	if ( ! current_user_can( 'update_plugins' ) || ! wp_autoupdates_is_plugins_auto_update_enabled() ) {
 		return;
 	}
-	if ( is_multisite() && ! is_network_admin() ) {
-		return;
-	}
+
 	if ( 'autoupdates_column' !== $column_name ) {
 		return;
 	}
+
 	$plugins = get_plugins();
 	$plugins_updates = get_site_transient( 'update_plugins' );
 	$page = isset( $_GET['paged'] ) && ! empty( $_GET['paged'] ) ? wp_unslash( esc_html( $_GET['paged'] ) ) : '';
+	$plugin_status = isset( $_GET['plugin_status'] ) && ! empty( $_GET['plugin_status'] ) ? wp_unslash( esc_html( $_GET['plugin_status'] ) ) : '';
+
 	if ( wp_autoupdates_is_plugins_auto_update_enabled() && wp_autoupdates_plugin_allows_auto_update( $plugin_file ) ) {
+		if ( ! isset( $plugins[ $plugin_file ] ) ) {
+			return;
+		}
+
 		$wp_auto_update_plugins = get_site_option( 'wp_auto_update_plugins', array() );
+
 		if ( in_array( $plugin_file, $wp_auto_update_plugins, true ) ) {
 			$aria_label = esc_attr(
 				sprintf(
@@ -120,7 +127,7 @@ function wp_autoupdates_add_plugins_autoupdates_column_content( $column_name, $p
 				)
 			);
 			echo '<p>';
-			echo '<span class="plugin-autoupdate-enabled"><span class="dashicons dashicons-update" aria-hidden="true"></span> ' . __( 'Enabled', 'wp-autoupdates' ) . '</span>';
+			echo '<span class="plugin-autoupdate-enabled">' . __( 'Auto-updates enabled', 'wp-autoupdates' ) . '</span>';
 			echo '<br />';
 			$next_update_time = wp_next_scheduled( 'wp_version_check' );
 			$time_to_next_update = human_time_diff( intval( $next_update_time ) );
@@ -135,7 +142,7 @@ function wp_autoupdates_add_plugins_autoupdates_column_content( $column_name, $p
 			if ( current_user_can( 'update_plugins', $plugin_file ) ) {
 				echo sprintf(
 					'<a href="%s" class="plugin-autoupdate-disable" aria-label="%s">%s</a>',
-					wp_nonce_url( 'plugins.php?action=autoupdate&amp;plugin=' . urlencode( $plugin_file ) . '&amp;paged=' . $page, 'autoupdate-plugin_' . $plugin_file ),
+					wp_nonce_url( 'plugins.php?action=autoupdate&amp;plugin=' . urlencode( $plugin_file ) . '&amp;paged=' . $page . '&amp;plugin_status=' . $plugin_status, 'autoupdate-plugin_' . $plugin_file ),
 					$aria_label,
 					__( 'Disable', 'wp-autoupdates' )
 				);
@@ -153,7 +160,7 @@ function wp_autoupdates_add_plugins_autoupdates_column_content( $column_name, $p
 				echo '<p class="plugin-autoupdate-disabled">';
 				echo sprintf(
 					'<a href="%s" class="edit" aria-label="%s"><span class="dashicons dashicons-update" aria-hidden="true"></span> %s</a>',
-					wp_nonce_url( 'plugins.php?action=autoupdate&amp;plugin=' . urlencode( $plugin_file ) . '&amp;paged=' . $page, 'autoupdate-plugin_' . $plugin_file ),
+					wp_nonce_url( 'plugins.php?action=autoupdate&amp;plugin=' . urlencode( $plugin_file ) . '&amp;paged=' . $page . '&amp;plugin_status=' . $plugin_status, 'autoupdate-plugin_' . $plugin_file ),
 					$aria_label,
 					__( 'Enable', 'wp-autoupdates' )
 				);
@@ -174,6 +181,7 @@ function wp_autoupdates_plugins_bulk_actions( $actions ) {
     return $actions;
 }
 add_action( 'bulk_actions-plugins', 'wp_autoupdates_plugins_bulk_actions' );
+add_action( 'bulk_actions-plugins-network', 'wp_autoupdates_plugins_bulk_actions' );
 
 
 /**
@@ -196,6 +204,8 @@ function wp_autoupdates_enabler() {
 
 		$plugin = ! empty( esc_html( $_GET['plugin'] ) ) ? wp_unslash( esc_html( $_GET['plugin'] ) ) : '';
 		$page   = isset( $_GET['paged'] ) && ! empty( esc_html( $_GET['paged'] ) ) ? wp_unslash( esc_html( $_GET['paged'] ) ) : '';
+		$status = isset( $_GET['plugin_status'] ) && ! empty( esc_html( $_GET['plugin_status'] ) ) ? wp_unslash( esc_html( $_GET['plugin_status'] ) ) : '';
+		$s      = isset( $_GET['s'] ) && ! empty( esc_html( $_GET['s'] ) ) ? wp_unslash( esc_html( $_GET['s'] ) ) : '';
 
 		if ( empty( $plugin ) ) {
 			wp_redirect( self_admin_url( "plugins.php?plugin_status=$status&paged=$page&s=$s" ) );
@@ -209,7 +219,7 @@ function wp_autoupdates_enabler() {
 			$wp_auto_update_plugins = array_diff( $wp_auto_update_plugins, array( $plugin ) );
 			$action_type = 'disable-autoupdate=true';
 		} else {
-			$wp_auto_update_plugins[] = $plugin;
+			array_push( $wp_auto_update_plugins, $plugin );
 			$action_type = 'enable-autoupdate=true';
 		}
 		update_site_option( 'wp_auto_update_plugins', $wp_auto_update_plugins );
@@ -237,6 +247,8 @@ function wp_autoupdates_plugins_bulk_actions_handle( $redirect_to, $doaction, $i
 
 		$plugins = ! empty( $items ) ? (array) wp_unslash( $items ) : array();
 		$page    = isset( $_GET['paged'] ) && ! empty( esc_html( $_GET['paged'] ) ) ? wp_unslash( esc_html( $_GET['paged'] ) ) : '';
+		$status  = isset( $_GET['plugin_status'] ) && ! empty( esc_html( $_GET['plugin_status'] ) ) ? wp_unslash( esc_html( $_GET['plugin_status'] ) ) : '';
+		$s       = isset( $_GET['s'] ) && ! empty( esc_html( $_GET['s'] ) ) ? wp_unslash( esc_html( $_GET['s'] ) ) : '';
 
 		if ( empty( $plugins ) ) {
 			$redirect_to = self_admin_url( "plugins.php?plugin_status=$status&paged=$page&s=$s" );
@@ -269,6 +281,9 @@ function wp_autoupdates_plugins_bulk_actions_handle( $redirect_to, $doaction, $i
 		check_admin_referer( 'bulk-plugins' );
 
 		$plugins = ! empty( $items ) ? (array) wp_unslash( $items ) : array();
+		$page    = isset( $_GET['paged'] ) && ! empty( esc_html( $_GET['paged'] ) ) ? wp_unslash( esc_html( $_GET['paged'] ) ) : '';
+		$status  = isset( $_GET['plugin_status'] ) && ! empty( esc_html( $_GET['plugin_status'] ) ) ? wp_unslash( esc_html( $_GET['plugin_status'] ) ) : '';
+		$s       = isset( $_GET['s'] ) && ! empty( esc_html( $_GET['s'] ) ) ? wp_unslash( esc_html( $_GET['s'] ) ) : '';
 
 		if ( empty( $plugins ) ) {
 			$redirect_to = self_admin_url( "plugins.php?plugin_status=$status&paged=$page&s=$s" );
@@ -291,6 +306,26 @@ function wp_autoupdates_plugins_bulk_actions_handle( $redirect_to, $doaction, $i
 	
 }
 add_action( 'handle_bulk_actions-plugins', 'wp_autoupdates_plugins_bulk_actions_handle', 10, 3 );
+add_action( 'handle_bulk_actions-plugins-network', 'wp_autoupdates_plugins_bulk_actions_handle', 10, 3 );
+
+
+/**
+ * Handle cleanup when plugin deleted
+ */
+function wp_autoupdates_plugin_deleted( $plugin_file, $deleted ) {
+	// Do nothing if the plugin wasn't deleted
+	if ( ! $deleted ) {
+		return;
+	}
+
+	// Remove settings
+	$wp_auto_update_plugins = get_site_option( 'wp_auto_update_plugins', array() );
+	if ( in_array( $plugin_file, $wp_auto_update_plugins, true ) ) {
+		$wp_auto_update_plugins = array_diff( $wp_auto_update_plugins, array( $plugin_file ) );
+		update_site_option( 'wp_auto_update_plugins', $wp_auto_update_plugins );
+	}
+}
+add_action( 'deleted_plugin', 'wp_autoupdates_plugin_deleted', 10, 2 );
 
 
 /**
@@ -320,3 +355,215 @@ add_action( 'admin_notices', 'wp_autoupdates_notices' );
 function wp_autoupdates_plugin_allows_auto_update( $plugin_file ) {
 	return apply_filters( 'wp_plugin_allows_auto_update', true, $plugin_file );
 }
+
+/**
+ * Add views for auto-update enabled/disabled.
+ *
+ * This is modeled on `WP_Plugins_List_Table::get_views()`.  If this is merged into core,
+ * then this should be encorporated there.
+ *
+ * @global array  $totals Counts by plugin_status, set in `WP_Plugins_List_Table::prepare_items()`.
+ */
+function wp_autoupdates_plugins_status_links( $status_links ) {
+	global $totals;
+
+	if ( ! current_user_can( 'update_plugins' ) || ! wp_autoupdates_is_plugins_auto_update_enabled() ) {
+		return $status_links;
+	}
+
+	$wp_autoupdate_plugins = get_site_option( 'wp_auto_update_plugins', array() );
+	$wp_autoupdate_plugins = array_intersect( $wp_autoupdate_plugins, array_keys( get_plugins() ) );
+	$enabled_count         = count( $wp_autoupdate_plugins );
+
+	// when merged, these counts will need to be set in WP_Plugins_List_Table::prepare_items().
+	$counts = array(
+		'autoupdate_enabled'  => $enabled_count,
+		'autoupdate_disabled' => $totals['all'] - $enabled_count,
+	);
+
+	// we can't use the global $status set in WP_Plugin_List_Table::__construct() because
+	// it will be 'all' for our "custom statuses".
+	$status = isset( $_REQUEST['plugin_status'] ) ? $_REQUEST['plugin_status'] : 'all';
+
+	foreach ( $counts as $type => $count ) {
+		if ( 0 === $count ) {
+			continue;
+		}
+		switch( $type ) {
+			case 'autoupdate_enabled':
+				/* translators: %s: Number of plugins. */
+				$text = _n(
+					'Auto-updates Enabled <span class="count">(%s)</span>',
+					'Auto-updates Enabled <span class="count">(%s)</span>',
+					$count,
+					'wp-autoupdates'
+				);
+
+				break;
+			case 'autoupdate_disabled':
+				/* translators: %s: Number of plugins. */
+				$text = _n(
+					'Auto-updates Disabled <span class="count">(%s)</span>',
+					'Auto-updates Disabled <span class="count">(%s)</span>',
+					$count,
+					'wp-autoupdates'
+				);
+		}
+
+		$status_links[ $type ] = sprintf(
+			"<a href='%s'%s>%s</a>",
+			add_query_arg( 'plugin_status', $type, 'plugins.php' ),
+			( $type === $status ) ? ' class="current" aria-current="page"' : '',
+			sprintf( $text, number_format_i18n( $count ) )
+		);
+	}
+
+	// make the 'all' status link not current if one of our "custom statuses" is current.
+	if ( in_array( $status, array_keys( $counts ) ) ) {
+		$status_links['all'] = str_replace( ' class="current" aria-current="page"', '', $status_links['all'] );
+	}
+
+	return $status_links;
+}
+add_action( is_multisite() ? 'views_plugins-network' : 'views_plugins', 'wp_autoupdates_plugins_status_links' );
+
+/**
+ * Filter plugins shown in the list table when status is 'auto-update-enabled' or 'auto-update-disabled'.
+ *
+ * This is modeled on `WP_Plugins_List_Table::prepare_items()`.  If this is merged into core,
+ * then this should be encorporated there.
+ *
+ * This action this is hooked to is fired in `wp-admin/plugins.php`.
+ *
+ * @global WP_Plugins_List_Table $wp_list_table The global list table object.  Set in `wp-admin/plugins.php`.
+ * @global int                   $page          The current page of plugins displayed.  Set in WP_Plugins_List_Table::__construct().
+ */
+function wp_autoupdates_plugins_filter_plugins_by_status( $plugins ) {
+	global $wp_list_table, $page;
+
+	$custom_statuses = array(
+		'autoupdate_enabled',
+		'autoupdate_disabled',
+	);
+
+	if ( ! ( isset( $_REQUEST['plugin_status'] ) &&
+			in_array( $_REQUEST['plugin_status'], $custom_statuses ) ) ) {
+		// current request is not for one of our statuses.
+		// nothing to do, so bail.
+		return;
+	}
+
+	$wp_auto_update_plugins = get_site_option( 'wp_auto_update_plugins', array() );
+	$_plugins = array();
+	foreach ( $plugins as $plugin_file => $plugin_data ) {
+		switch ( $_REQUEST['plugin_status'] ) {
+			case 'autoupdate_enabled':
+				if ( in_array( $plugin_file, $wp_auto_update_plugins ) ) {
+					$_plugins[ $plugin_file ] = _get_plugin_data_markup_translate( $plugin_file, $plugin_data, false, true );
+				}
+				break;
+			case 'autoupdate_disabled':
+				if ( ! in_array( $plugin_file, $wp_auto_update_plugins ) ) {
+					$_plugins[ $plugin_file ] = _get_plugin_data_markup_translate( $plugin_file, $plugin_data, false, true );
+				}
+				break;
+		}
+	}
+
+	// set the list table's items array to just those plugins with our custom status.
+	$wp_list_table->items = $_plugins;
+
+	// now, update the pagination properties of the list table accordingly.
+	$total_this_page = count( $_plugins );
+
+	$plugins_per_page = $wp_list_table->get_items_per_page( str_replace( '-', '_', $wp_list_table->screen->id . '_per_page' ), 999 );
+
+	$start = ( $page - 1 ) * $plugins_per_page;
+
+	if ( $total_this_page > $plugins_per_page ) {
+		$wp_list_table->items = array_slice( $wp_list_table->items, $start, $plugins_per_page );
+	}
+
+	$wp_list_table->set_pagination_args(
+		array(
+			'total_items' => $total_this_page,
+			'per_page'    => $plugins_per_page,
+		)
+	);
+
+	return;
+}
+add_action( 'pre_current_active_plugins', 'wp_autoupdates_plugins_filter_plugins_by_status' );
+
+/*
+ * Populate site health informations
+ */
+function wp_autoupdates_debug_information( $info ) {
+	if ( wp_autoupdates_is_plugins_auto_update_enabled() ) {
+		// Populate plugins informations
+		$wp_auto_update_plugins = get_site_option( 'wp_auto_update_plugins', array() );
+
+		$plugins        = get_plugins();
+		$plugin_updates = get_plugin_updates();
+
+		foreach ( $plugins as $plugin_path => $plugin ) {
+			$plugin_part = ( is_plugin_active( $plugin_path ) ) ? 'wp-plugins-active' : 'wp-plugins-inactive';
+
+			$plugin_version = $plugin['Version'];
+			$plugin_author  = $plugin['Author'];
+
+			$plugin_version_string       = __( 'No version or author information is available.', 'wp-autoupdates' );
+			$plugin_version_string_debug = __( 'author: (undefined), version: (undefined)', 'wp-autoupdates' );
+
+			if ( ! empty( $plugin_version ) && ! empty( $plugin_author ) ) {
+				/* translators: 1: Plugin version number. 2: Plugin author name. */
+				$plugin_version_string       = sprintf( __( 'Version %1$s by %2$s', 'wp-autoupdates' ), $plugin_version, $plugin_author );
+				/* translators: 1: Plugin version number. 2: Plugin author name. */
+				$plugin_version_string_debug = sprintf( __( 'version: %1$s, author: %2$s', 'wp-autoupdates' ), $plugin_version, $plugin_author );
+			} else {
+				if ( ! empty( $plugin_author ) ) {
+					/* translators: %s: Plugin author name. */
+					$plugin_version_string       = sprintf( __( 'By %s', 'wp-autoupdates' ), $plugin_author );
+					/* translators: %s: Plugin author name. */
+					$plugin_version_string_debug = sprintf( __( 'author: %s, version: (undefined)', 'wp-autoupdates' ), $plugin_author );
+				}
+				if ( ! empty( $plugin_version ) ) {
+					/* translators: %s: Plugin version number. */
+					$plugin_version_string       = sprintf( __( 'Version %s', 'wp-autoupdates' ), $plugin_version );
+					/* translators: %s: Plugin version number. */
+					$plugin_version_string_debug = sprintf( __( 'author: (undefined), version: %s', 'wp-autoupdates' ), $plugin_version );
+				}
+			}
+
+			if ( array_key_exists( $plugin_path, $plugin_updates ) ) {
+				/* translators: %s: Latest plugin version number. */
+				$plugin_version_string       .= ' ' . sprintf( __( '(Latest version: %s)', 'wp-autoupdates' ), $plugin_updates[ $plugin_path ]->update->new_version );
+				/* translators: %s: Latest plugin version number. */
+				$plugin_version_string_debug .= ' ' . sprintf( __( '(latest version: %s)', 'wp-autoupdates' ), $plugin_updates[ $plugin_path ]->update->new_version );
+			}
+
+			if ( in_array( $plugin_path, $wp_auto_update_plugins ) ) {
+				$plugin_version_string       .= ' | ' . sprintf( __( 'Auto-updates enabled', 'wp-autoupdates' ) );
+				$plugin_version_string_debug .= sprintf( __( 'auto-updates enabled', 'wp-autoupdates' ) );
+			} else {
+				$plugin_version_string       .= ' | ' . sprintf( __( 'Auto-updates disabled', 'wp-autoupdates' ) );
+				$plugin_version_string_debug .= sprintf( __( 'auto-updates disabled', 'wp-autoupdates' ) );
+			}
+
+			$info[ $plugin_part ]['fields'][ sanitize_text_field( $plugin['Name'] ) ] = array(
+				'label' => $plugin['Name'],
+				'value' => $plugin_version_string,
+				'debug' => $plugin_version_string_debug,
+			);
+		}
+	}
+	// Populate constants informations
+	$enabled = defined( 'WP_DISABLE_PLUGINS_AUTO_UPDATE' ) ? WP_DISABLE_PLUGINS_AUTO_UPDATE : __( 'Undefined', 'wp-autoupdates' );
+	$info['wp-constants']['fields']['WP_DISABLE_PLUGINS_AUTO_UPDATE'] = array(
+		'label' => 'WP_DISABLE_PLUGINS_AUTO_UPDATE',
+		'value' => $enabled,
+		'debug' => strtolower( $enabled ),
+	);
+	return $info;
+}
+add_filter( 'debug_information', 'wp_autoupdates_debug_information' );

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -243,6 +243,9 @@ function wp_autoupdates_plugins_bulk_actions_handle( $redirect_to, $doaction, $i
 			return $redirect_to;
 		}
 
+		// Filter can be used to remove plugins from being enabled via bulk action.
+		$plugins = apply_filters( 'wp_plugin_bulk_enabled_autoupdate', $plugins );
+
 		$previous_autoupdated_plugins = get_site_option( 'wp_auto_update_plugins', array() );
 
 		$new_autoupdated_plugins = array_merge( $previous_autoupdated_plugins, $plugins );
@@ -271,6 +274,9 @@ function wp_autoupdates_plugins_bulk_actions_handle( $redirect_to, $doaction, $i
 			$redirect_to = self_admin_url( "plugins.php?plugin_status=$status&paged=$page&s=$s" );
 			return $redirect_to;
 		}
+
+		// Filter can be used to remove plugins from being disabled via bulk action.
+		$plugins = apply_filters( 'wp_plugin_bulk_disabled_autoupdate', $plugins );
 
 		$previous_autoupdated_plugins = get_site_option( 'wp_auto_update_plugins', array() );
 


### PR DESCRIPTION
This PR allows plugins to remove the option for users to enable auto updates for a specific plugin on the plugins table.

Since the table columns can not be filtered and only allows you to add content, this allows the action to have a condition for a specific plugin.

## Example of use in a plugin

```php
function disable_auto_updates_action( $status, $plugin_file ) {
	if ( $plugin_file === 'cocart-pro/cocart-pro.php' ) {
		return false;
	}

	return $status;
}
add_filter( 'wp_plugin_allows_auto_update', 'disable_auto_updates_action', 10, 2 );
```