### PR TITLE
Remove dashicon from Enable text in plugins auto-updates column

### DIFF
--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -116,7 +116,7 @@ function wp_autoupdates_add_plugins_autoupdates_column_content( $column_name, $p
 				)
 			);
 			echo '<p>';
-			echo '<span class="plugin-autoupdate-enabled"><span class="dashicons dashicons-update" aria-hidden="true"></span> ' . __( 'Enabled', 'wp-autoupdates' ) . '</span>';
+			echo '<span class="plugin-autoupdate-enabled">' . __( 'Auto-updates enabled', 'wp-autoupdates' ) . '</span>';
 			echo '<br />';
 			$next_update_time = wp_next_scheduled( 'wp_version_check' );
 			$time_to_next_update = human_time_diff( intval( $next_update_time ) );


### PR DESCRIPTION
For reference, see @mapk’s design feedback on Make/Core:
- https://make.wordpress.org/core/2020/02/26/feature-plugin-wp-auto-updates/#comment-37993