### PR TITLE
Remove update time text after manual update

### DIFF
--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -9,7 +9,7 @@ Requires PHP: 5.6
 Tested up to: 5.4
 Author: The WordPress Team
 Author URI: https://wordpress.org
-Contributors: wordpressdotorg, audrasjb, whodunitagency, pbiron, xkon, karmatosed, mapk, bookdude13
+Contributors: wordpressdotorg, audrasjb, whodunitagency, pbiron, xkon, karmatosed, mapk
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: wp-autoupdates

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -9,7 +9,7 @@ Requires PHP: 5.6
 Tested up to: 5.4
 Author: The WordPress Team
 Author URI: https://wordpress.org
-Contributors: wordpressdotorg, audrasjb, whodunitagency, pbiron, xkon, karmatosed, mapk
+Contributors: wordpressdotorg, audrasjb, whodunitagency, pbiron, xkon, karmatosed, mapk, bookdude13
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: wp-autoupdates
@@ -48,6 +48,20 @@ function wp_autoupdates_enqueues( $hook ) {
 			}
 		}
 		$script .= '});';
+		wp_add_inline_script( 'jquery', $script );
+	}
+
+	// When manually updating a plugin the 'time until next update' text needs to be hidden.
+	// Doesn't need to be done on the update-core.php page since that page refreshes after an update.
+	if ( 'plugins.php' === $hook ) {
+		$script = 'jQuery( document ).ready(function() {
+			jQuery( ".update-link" ).click( function() {
+				var plugin = jQuery( this ).closest("tr").data("plugin");
+				var plugin_row = jQuery( "tr.update[data-plugin=\'" + plugin + "\']" );
+				var plugin_auto_update_time_text = plugin_row.find("span.plugin-autoupdate-time");
+				plugin_auto_update_time_text.text("");
+			});
+		});';
 		wp_add_inline_script( 'jquery', $script );
 	}
 }
@@ -126,12 +140,14 @@ function wp_autoupdates_add_plugins_autoupdates_column_content( $column_name, $p
 			$next_update_time = wp_next_scheduled( 'wp_version_check' );
 			$time_to_next_update = human_time_diff( intval( $next_update_time ) );
 			if ( isset( $plugins_updates->response[$plugin_file] ) ) {
+				echo '<span class="plugin-autoupdate-time">';
 				echo sprintf(
 					/* translators: Time until the next update. */
 					__( 'Update scheduled in %s', 'wp-autoupdates' ),
 					$time_to_next_update
 				);
 				echo '<br />';
+				echo '</span>';
 			}
 			if ( current_user_can( 'update_plugins', $plugin_file ) ) {
 				echo sprintf(

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -59,7 +59,7 @@ function wp_autoupdates_enqueues( $hook ) {
 				var plugin = jQuery( this ).closest("tr").data("plugin");
 				var plugin_row = jQuery( "tr.update[data-plugin=\'" + plugin + "\']" );
 				var plugin_auto_update_time_text = plugin_row.find("span.plugin-autoupdate-time");
-				plugin_auto_update_time_text.text("");
+				plugin_auto_update_time_text.remove();
 			});
 		});';
 		wp_add_inline_script( 'jquery', $script );


### PR DESCRIPTION
Fixes #28. 

Note that in #28 the issue disappeared after a refresh, since the page reloading set the text properly. I didn't think a page reload made sense after an update (especially since multiple updates may occur with bulk actions), so I added a jQuery hook. If there are coding standard changes, or a better place to put this, let me know and I can update it. I'm always ready to learn 😄 