### PR TITLE
Add themes autoupdates support basis

### DIFF
--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -99,6 +99,20 @@ add_filter( 'auto_update_plugin', 'wp_autoupdates_selected_plugins', 10, 2 );
 
 
 /**
+ * Autoupdate selected themes.
+ */
+function wp_autoupdates_selected_themes( $update, $item ) {
+	$wp_auto_update_themes = get_site_option( 'wp_auto_update_themes', array() );
+	if ( in_array( $item->theme, $wp_auto_update_themes, true ) && wp_autoupdates_is_themes_auto_update_enabled() ) {
+		return true;
+	} else {
+		return $update;
+	}
+}
+add_filter( 'auto_update_theme', 'wp_autoupdates_selected_themes', 10, 2 );
+
+
+/**
  * Add autoupdate column to plugins screen.
  */
 function wp_autoupdates_add_plugins_autoupdates_column( $columns ) {

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -55,17 +55,32 @@ add_action( 'admin_enqueue_scripts', 'wp_autoupdates_enqueues' );
 
 
 /**
- * Checks whether plugins manual autoupdate is enabled.
+ * Checks whether plugins manual auto-update is enabled.
  */
 function wp_autoupdates_is_plugins_auto_update_enabled() {
 	$enabled = ! defined( 'WP_DISABLE_PLUGINS_AUTO_UPDATE' ) || ! WP_DISABLE_PLUGINS_AUTO_UPDATE;
 	
 	/**
-	 * Filters whether plugins manual autoupdate is enabled.
+	 * Filters whether plugins manual auto-update is enabled.
 	 *
-	 * @param bool $enabled True if plugins auto udpate is enabled, false otherwise.
+	 * @param bool $enabled True if plugins auto-udpate is enabled, false otherwise.
 	 */
 	return apply_filters( 'wp_plugins_auto_update_enabled', $enabled );
+}
+
+
+/**
+ * Checks whether themes manual auto-update is enabled.
+ */
+function wp_autoupdates_is_themes_auto_update_enabled() {
+	$enabled = ! defined( 'WP_DISABLE_THEMES_AUTO_UPDATE' ) || ! WP_DISABLE_THEMES_AUTO_UPDATE;
+	
+	/**
+	 * Filters whether themes manual auto-update is enabled.
+	 *
+	 * @param bool $enabled True if themes auto-udpate is enabled, false otherwise.
+	 */
+	return apply_filters( 'wp_themes_auto_update_enabled', $enabled );
 }
 
 


### PR DESCRIPTION
Let's support themes auto-updates as well!
Introducing:
- `wp_autoupdates_is_themes_auto_update_enabled()` function
- `wp_autoupdates_selected_themes()` function that hook on `auto_update_theme` filter