### PR TITLE
Further basis for themes auto-updates

### DIFF
--- a/css/wp-autoupdates.css
+++ b/css/wp-autoupdates.css
@@ -2,11 +2,13 @@
 	min-width: 200px;
 }
 
-.autoupdates_column .plugin-autoupdate-enabled {
+.autoupdates_column .plugin-autoupdate-enabled,
+.theme-overlay .theme-autoupdate-enabled a {
 	color: #006505;
 }
 
-.autoupdates_column .plugin-autoupdate-disable {
+.autoupdates_column .plugin-autoupdate-disable,
+.theme-overlay .theme-autoupdate-disabled a {
 	color: #a00;
 }
 
@@ -27,4 +29,8 @@
 	box-shadow: none;
 	font-size: 20px;
 	color: #006505;
+}
+
+.theme-overlay .theme-autoupdate a {
+	text-decoration: none;
 }

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -109,7 +109,7 @@ function wp_autoupdates_prepare_themes_for_js( $prepared_themes ) {
 		$slug = $theme['id'];
 		$encoded_slug = urlencode( $slug );
 		$theme['autoupdate'] = in_array( $slug, $wp_auto_update_themes, true );
-		$theme['actions']['autoupdate'] = current_user_can( 'update_themes' ) ? wp_nonce_url( admin_url( 'themes.php?action=autoupdate&amp;stylesheet=' . $encoded_slug ), 'autoupdate-theme_' . $slug ) : null;
+		$theme['actions']['autoupdate'] = current_user_can( 'update_themes' ) ? wp_nonce_url( admin_url( 'themes.php?action=autoupdate&amp;theme=' . $encoded_slug ), 'autoupdate-theme_' . $slug ) : null;
 
 		$prepared_themes[ $slug ] = $theme;
 	}

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -223,7 +223,7 @@ add_action( 'bulk_actions-plugins-network', 'wp_autoupdates_plugins_bulk_actions
 /**
  * Handles auto-updates enabling for plugins
  */
-function wp_autoupdates_enabler_plugins() {
+function wp_autoupdates_plugins_enabler() {
 	$action = isset( $_GET['action'] ) && ! empty( esc_html( $_GET['action'] ) ) ? wp_unslash( esc_html( $_GET['action'] ) ) : '';
 	if ( 'autoupdate' === $action ) {
 		if ( ! current_user_can( 'update_plugins' ) || ! wp_autoupdates_is_plugins_auto_update_enabled() ) {
@@ -264,7 +264,7 @@ function wp_autoupdates_enabler_plugins() {
 /**
  * Handles auto-updates enabling for themes
  */
-function wp_autoupdates_enabler_themes() {
+function wp_autoupdates_themes_enabler() {
 	$action = isset( $_GET['action'] ) && ! empty( esc_html( $_GET['action'] ) ) ? wp_unslash( esc_html( $_GET['action'] ) ) : '';
 	if ( 'autoupdate' === $action ) {
 		if ( ! current_user_can( 'update_themes' ) || ! wp_autoupdates_is_themes_auto_update_enabled() ) {
@@ -307,10 +307,10 @@ function wp_autoupdates_enabler_themes() {
 function wp_autoupdates_enabler() {
 	$pagenow = $GLOBALS['pagenow'];
 	if ( 'plugins.php' === $pagenow ) {
-		wp_autoupdates_enabler_plugins();
+		wp_autoupdates_plugins_enabler();
 	}
 	else if ( 'themes.php' === $pagenow ) {
-		wp_autoupdates_enabler_themes();
+		wp_autoupdates_themes_enabler();
 	}
 }
 add_action( 'admin_init', 'wp_autoupdates_enabler' );
@@ -411,7 +411,7 @@ add_action( 'deleted_plugin', 'wp_autoupdates_plugin_deleted', 10, 2 );
 /**
  * Auto-update notices for plugins
  */
-function wp_autoupdates_notices_plugins() {
+function wp_autoupdates_plugins_notices() {
 	if ( isset( $_GET['enable-autoupdate'] ) ) {
 		echo '<div id="message" class="notice notice-success is-dismissible"><p>';
 		_e( 'The selected plugins will now update automatically.', 'wp-autoupdates' );
@@ -428,7 +428,7 @@ function wp_autoupdates_notices_plugins() {
 /**
  * Auto-update notices for themes
  */
-function wp_autoupdates_notices_themes() {
+function wp_autoupdates_themes_notices() {
 	if ( isset( $_GET['enable-autoupdate'] ) ) {
 		echo '<div id="message" class="notice notice-success is-dismissible"><p>';
 		_e( 'The selected themes will now update automatically.', 'wp-autoupdates' );
@@ -449,10 +449,10 @@ function wp_autoupdates_notices() {
 	// Plugins screen
 	$pagenow = $GLOBALS['pagenow'];
 	if ( 'plugins.php' === $pagenow ) {
-		wp_autoupdates_notices_plugins();
+		wp_autoupdates_plugins_notices();
 	}
 	else if ( 'themes.php' === $pagenow ) {
-		wp_autoupdates_notices_themes();
+		wp_autoupdates_themes_notices();
 	}	
 }
 add_action( 'admin_notices', 'wp_autoupdates_notices' );

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -73,11 +73,11 @@ function wp_autoupdates_enqueues( $hook ) {
 			// Put the enable/disable link below the author and before the update box.
 			$autoupdate_text = '<p class="theme-autoupdate"> <# if ( data.autoupdate ) { #>';
 			$autoupdate_text .= '<span class="theme-autoupdate-disabled">';
-			$autoupdate_text .= '<a href="{{{ data.actions.autoupdate }}}" aria-label="' . $aria_label_disable . '"><span class="dashicons dashicons-update" aria-hidden="true"></span>' . __( 'Disable automatic updates' ) . '</a>';
+			$autoupdate_text .= '<a href="{{{ data.actions.autoupdate }}}" aria-label="' . $aria_label_disable . '"><span class="dashicons dashicons-update" aria-hidden="true"></span> ' . __( 'Disable automatic updates' ) . '</a>';
 			$autoupdate_text .= '</span>';
 			$autoupdate_text .= '<# } else { #>';
 			$autoupdate_text .= '<span class="theme-autoupdate-enabled">';
-			$autoupdate_text .= '<a href="{{{ data.actions.autoupdate }}}" aria-label="' . $aria_label_enable . '"><span class="dashicons dashicons-update" aria-hidden="true"></span>' . __( 'Enable automatic updates' ) . '</a>';
+			$autoupdate_text .= '<a href="{{{ data.actions.autoupdate }}}" aria-label="' . $aria_label_enable . '"><span class="dashicons dashicons-update" aria-hidden="true"></span> ' . __( 'Enable automatic updates' ) . '</a>';
 			$autoupdate_text .= '</span>';
 			$autoupdate_text .= '<# } #> </p>';
 

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -77,7 +77,6 @@ function wp_autoupdates_enqueues( $hook ) {
 			$autoupdate_text .= '<a href="{{{ data.actions.autoupdate }}}" aria-label="' . $aria_label_enable . '"><span class="dashicons dashicons-update" aria-hidden="true"></span>' . __( 'Enable automatic updates' ) . '</a>';
 			$autoupdate_text .= '<# } #> </p>';
 
-			$script .= '	window.console.log("here");';
 			$script .= '	const theme_template_single = jQuery( "#tmpl-theme-single" );
 
 				// Pull template into new html element, manipulate, then put back.
@@ -106,15 +105,16 @@ add_action( 'admin_enqueue_scripts', 'wp_autoupdates_enqueues' );
 function wp_autoupdates_prepare_themes_for_js( $prepared_themes ) {
 	$wp_auto_update_themes = get_option( 'wp_auto_update_themes', array() );
 	foreach( $prepared_themes as $theme ) {
-		// Set extra data for theme, for when this gets merged into core.
+		// Set extra data for use in the template.
 		$slug = $theme['id'];
 		$encoded_slug = urlencode( $slug );
 		$theme['autoupdate'] = in_array( $slug, $wp_auto_update_themes, true );
 		$theme['actions']['autoupdate'] = current_user_can( 'update_themes' ) ? wp_nonce_url( admin_url( 'themes.php?action=autoupdate&amp;stylesheet=' . $encoded_slug ), 'autoupdate-theme_' . $slug ) : null;
 	}
+
 	return $prepared_themes;
 }
-add_filter( 'wp_prepare_themes_for_js', 'wp_autoupdates_prepare_themes_for_js' );
+add_action( 'wp_prepare_themes_for_js', 'wp_autoupdates_prepare_themes_for_js' );
 
 
 /**

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -95,7 +95,6 @@ function wp_autoupdates_enqueues( $hook ) {
 
 						const new_template_text = template_text.substr(0, position) + added_text + template_text.substr(position);
 						theme_template_single.text( new_template_text );
-						window.console.log(new_template_text);
 					}
 				}
 

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -110,6 +110,8 @@ function wp_autoupdates_prepare_themes_for_js( $prepared_themes ) {
 		$encoded_slug = urlencode( $slug );
 		$theme['autoupdate'] = in_array( $slug, $wp_auto_update_themes, true );
 		$theme['actions']['autoupdate'] = current_user_can( 'update_themes' ) ? wp_nonce_url( admin_url( 'themes.php?action=autoupdate&amp;stylesheet=' . $encoded_slug ), 'autoupdate-theme_' . $slug ) : null;
+
+		$prepared_themes[ $slug ] = $theme;
 	}
 
 	return $prepared_themes;

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -72,9 +72,13 @@ function wp_autoupdates_enqueues( $hook ) {
  			$aria_label_disable = sprintf( _x( 'Disable automatic update for %s', 'theme' ), '{{ data.name }}' );
 
 			$autoupdate_text = '<p class="theme-autoupdate"> <# if ( data.autoupdate ) { #>';
+			$autoupdate_text .= '<span class="theme-autoupdate-disabled">';
 			$autoupdate_text .= '<a href="{{{ data.actions.autoupdate }}}" aria-label="' . $aria_label_disable . '"><span class="dashicons dashicons-update" aria-hidden="true"></span>' . __( 'Disable automatic updates' ) . '</a>';
+			$autoupdate_text .= '</span>';
 			$autoupdate_text .= '<# } else { #>';
+			$autoupdate_text .= '<span class="theme-autoupdate-enabled">';
 			$autoupdate_text .= '<a href="{{{ data.actions.autoupdate }}}" aria-label="' . $aria_label_enable . '"><span class="dashicons dashicons-update" aria-hidden="true"></span>' . __( 'Enable automatic updates' ) . '</a>';
+			$autoupdate_text .= '</span>';
 			$autoupdate_text .= '<# } #> </p>';
 
 			$script .= '	const theme_template_single = jQuery( "#tmpl-theme-single" );


### PR DESCRIPTION
Hey @audrasjb,

I had some time on my hands and found some of the JS hacks needed to get the updates with themes to work. This is built on top of the existing basis from #44. Let me know if there is a cleaner solution; right now the template is modified through some string replacement using jQuery. I haven't verified that the toggles actually work to enable/disable the updates, but the general logic flow works.

I wanted to post this now to avoid duplicate work being done 😃 