### PR TITLE
Add Themes auto-updates to update-core.php screen

### DIFF
--- a/css/wp-autoupdates.css
+++ b/css/wp-autoupdates.css
@@ -17,12 +17,14 @@
 	color: #006505;
 }
 
-.plugins .plugin-title .plugin-autoupdate-enabled .dashicons {
+.plugins .plugin-title .plugin-autoupdate-enabled .dashicons,
+#update-themes-table .plugin-title .dashicons {
 	float: none;
 	padding: 0;
 	width: auto;
 	height: auto;
 }
+
 .plugins .plugin-title .plugin-autoupdate-enabled .dashicons:before {
 	padding: 0;
 	background: transparent;

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -33,6 +33,19 @@ function wp_autoupdates_enqueues( $hook ) {
 	// Update core screen JS hack (due to lack of filters)
 	if ( 'update-core.php' === $hook ) {
 		$script = 'jQuery( document ).ready(function() {';
+
+		if ( wp_autoupdates_is_themes_auto_update_enabled() ) {
+			$wp_auto_update_themes = get_site_option( 'wp_auto_update_themes', array() );
+
+			$update_message = wp_autoupdates_get_update_message();
+			foreach ( $wp_auto_update_themes as $theme ) {
+				$autoupdate_text = ' <span class="plugin-autoupdate-enabled"><span class="dashicons dashicons-update" aria-hidden="true"></span> ';
+				$autoupdate_text .= $update_message;
+				$autoupdate_text .= '</span> ';
+				$script .= 'jQuery(".check-column input[value=\'' . $theme . '\']").closest("tr").find(".plugin-title > p").append(\'' . $autoupdate_text . '\');';
+			}
+		}
+
 		if ( wp_autoupdates_is_plugins_auto_update_enabled() ) {
 			$wp_auto_update_plugins = get_site_option( 'wp_auto_update_plugins', array() );
 


### PR DESCRIPTION
Added UI for Themes auto-updates to `update-core.php` screen.

![Capture d’écran 2020-03-24 à 22 08 39](https://user-images.githubusercontent.com/1590998/77477528-cadf6880-6e1c-11ea-97cc-f7e0405e6b51.png)
